### PR TITLE
mapOf logic updates

### DIFF
--- a/distribution/src/jadn/translate/jsonschema_w.py
+++ b/distribution/src/jadn/translate/jsonschema_w.py
@@ -299,14 +299,49 @@ def t_map(tdef: list, topts: dict, ctx: dict) -> dict:
 def t_map_of(tdef: list, topts: dict, ctx: dict) -> dict:
     items = get_items(topts['ktype'], ctx)
     vtype = w_kvtype(topts['vtype'], ctx)
-    return dmerge(
+    ktype = w_kvtype(topts['ktype'], ctx)
+    
+    opts = tdef[TypeOptions]
+    k_opt = opts[0]
+    k_name = k_opt[1:]
+    
+    v_opt = opts[1]
+    v_name = v_opt[1:]
+    
+    items_new = {
+        "type" : "object",
+        k_name : ktype,
+        v_name : vtype
+    }
+    
+    merged = dmerge(
+        # w_td('object', tdef[TypeDesc]),
         w_td('object', tdef[TypeDesc]),
+        
         {'additionalProperties': False},
         {'minProperties': topts['minv']} if topts.get('minv', 0) != 0 else {},
         {'maxProperties': topts['maxv']} if 'maxv' in topts else {},
-        {'patternProperties': {pattern(items): vtype}} if items and ctx['enum_style'] == 'regex' else
-        {'properties': {f: vtype for f in items}} if items else {}
+        {'patternProperties': {pattern(items): vtype}} if items and ctx['enum_style'] == 'regex' else {}
+        # {'items': w_kvtype(topts['vtype'], ctx)}
+        # {'items', k_dict, v_dict}
+        # {'properties': {f: vtype for f in items}} if items else {}
     )
+    
+    merged['items'] = items_new
+    return merged
+    
+    # return dmerge(
+    #     # w_td('object', tdef[TypeDesc]),
+    #     w_td('array', tdef[TypeDesc]),
+        
+    #     {'additionalProperties': False},
+    #     {'minProperties': topts['minv']} if topts.get('minv', 0) != 0 else {},
+    #     {'maxProperties': topts['maxv']} if 'maxv' in topts else {},
+    #     {'patternProperties': {pattern(items): vtype}} if items and ctx['enum_style'] == 'regex' else
+    #     # {'items': w_kvtype(topts['vtype'], ctx)}
+    #     {'items', items_new}
+    #     # {'properties': {f: vtype for f in items}} if items else {}
+    # )
 
 
 # Type Map Util

--- a/distribution/src/jadn/translate/jsonschema_w.py
+++ b/distribution/src/jadn/translate/jsonschema_w.py
@@ -344,19 +344,6 @@ def t_map_of(tdef: list, topts: dict, ctx: dict) -> dict:
         merged['items'] = prefix_items        
     
     return merged
-    
-    # return dmerge(
-    #     # w_td('object', tdef[TypeDesc]),
-    #     w_td('array', tdef[TypeDesc]),
-        
-    #     {'additionalProperties': False},
-    #     {'minProperties': topts['minv']} if topts.get('minv', 0) != 0 else {},
-    #     {'maxProperties': topts['maxv']} if 'maxv' in topts else {},
-    #     {'patternProperties': {pattern(items): vtype}} if items and ctx['enum_style'] == 'regex' else
-    #     # {'items': w_kvtype(topts['vtype'], ctx)}
-    #     {'items', items_new}
-    #     # {'properties': {f: vtype for f in items}} if items else {}
-    # )
 
 
 # Type Map Util


### PR DESCRIPTION
Updated the jsonschema_w.py / t_map_of logic to hand a ktype of string or non-string, then add the respective json schema elements.   Previously the mapOf created an object that did not point to any other types, which leads to zero data generation based on the json schema for mapOfs. 